### PR TITLE
Re-brand and centralise documentation

### DIFF
--- a/README.md
+++ b/README.md
@@ -37,7 +37,6 @@ The Web Thing API is the REST & WebSockets API used by the WebThings IoT platfor
 * [Creating a new translation](https://github.com/WebThingsIO/wiki/wiki/Fluent%3A-Making-a-new-translation)
 * [Testing pre-release OTA updates](https://github.com/WebThingsIO/wiki/wiki/Testing-prerelease-OTA-updates)
 * [Releasing a Gateway OTA Update](https://github.com/WebThingsIO/wiki/wiki/How-To-Release-a-Gateway-OTA-Update)
-* [Using the staging server](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Use-the-staging-server-for-testing)
 #### Add-Ons
 * [Introduction to Add-ons](https://github.com/WebThingsIO/addon-list/blob/master/guidelines.md)
 * [Creating an Add-on](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Create-an-add-on)

--- a/README.md
+++ b/README.md
@@ -1,35 +1,99 @@
-# Mozilla WebThings
+# WebThings
 
-[Mozilla WebThings](https://iot.mozilla.org/) is an open platform for monitoring and controlling devices over the web.
+[WebThings](https://webthings.io/) is an open platform for monitoring and controlling devices over the web.
 
 It is an open source implementation of emerging [Web of Things](https://www.w3.org/WoT/) standards at the W3C.
 
-## WebThings Gateway
-[WebThings Gateway](https://iot.mozilla.org/gateway/) is a software distribution for smart home gateways which allows users to directly monitor and control their smart home over the web, without a middleman.
-* 📝 [Getting Started Guide - Raspberry Pi](./gateway-getting-started-guide.md)
-* 📝 [User Guide](./gateway-user-guide.md)
-* 🌐 [Supported Hardware](https://github.com/WebThingsIO/wiki/wiki/Supported-Hardware)
+## User Guide
+### WebThings Gateway
+[WebThings Gateway](https://webthings.io/gateway/) is a software distribution for smart home gateways which allows users to directly monitor and control their smart home over the web, without a middleman.
+* [Getting Started Guide - Raspberry Pi](./gateway-getting-started-guide.md)
+* [Getting Started Guide - Docker](https://github.com/WebThingsIO/gateway-docker/blob/master/README.md)
+* [User Guide](./gateway-user-guide.md)
+* [Supported Hardware](https://github.com/WebThingsIO/wiki/wiki/Supported-Hardware)
+#### Tips
+* [Pairing SmartThings sensors](https://github.com/WebThingsIO/wiki/wiki/Pairing-SmartThings-sensors)
+* [Configuring the Arlec Smart Plug](https://github.com/WebThingsIO/wiki/wiki/Arlec-Smart-Plug)
+* [Factory reset a Cree Connected bulb](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Factory-reset-a-Cree-Connected-bulb)
+* [Factory reset a Hue bulb](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Factory-reset-a-Hue-bulb)
+* [Factory reset a Hue Wireless Dimmer](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Factory-reset-a-Hue-Wireless-Dimmer)
+* [Factory reset an IKEA bulb](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Factory-reset-an-IKEA-bulb)
 
-### Development
-* 🌐 [Docker Image](https://hub.docker.com/r/mozillaiot/gateway)
-* 🌐 [Build Instructions](https://github.com/WebThingsIO/gateway#readme)
 
-## WebThings Framework
+## Developer Guide
 
-[WebThings Framework](https://iot.mozilla.org/framework/) is a collection of re-usable software components to help developers build their own web things which directly expose the Web Thing API.
+### Web Thing API
+The Web Thing API is the REST & WebSockets API used by the WebThings IoT platform for monitoring and controlling devices over the web. Parts of the Web Thing API specification are currently being standardised via the W3C.
+* [Introduction to the Web Thing API](https://github.com/WebThingsIO/wot/blob/gh-pages/README.md)
+* [Web Thing API specification](https://webthings.io/api/)
+  * [Examples using curl](https://github.com/WebThingsIO/curl-examples/blob/master/README.md)
+  * [Differences with W3C specification](https://github.com/webthingsio/wiki/wiki/Mozilla-W3C-Differences)
+* [WoT Capability Schemas](https://webthings.io/schemas/)
 
-### Libraries
-* 🌐 [Node.js](https://github.com/WebThingsIO/webthing-node)
-* 🌐 [Python](https://github.com/WebThingsIO/webthing-python)
-* 🌐 [Java](https://github.com/WebThingsIO/webthing-java)
-* 🌐 [Rust](https://github.com/WebThingsIO/webthing-rust)
-* 🌐 [Arduino](https://github.com/WebThingsIO/webthing-arduino)
-* 🌐 [MicroPython](https://github.com/WebThingsIO/webthing-upy)
+### WebThings Gateway
+[WebThings Gateway](https://webthings.io/gateway/) is an open source implementation of a Web of Things gateway which bridges a range of different IoT protocols to the Web Thing API and provides a web interface for users to monitor and control devices.
+* [Gateway Architecture](https://github.com/WebThingsIO/wiki/wiki/Gateway-Architecture)
+* [Build Instructions](https://github.com/WebThingsIO/gateway#readme)
+* [Creating a new translation](https://github.com/WebThingsIO/wiki/wiki/Fluent%3A-Making-a-new-translation)
+* [Testing pre-release OTA updates](https://github.com/WebThingsIO/wiki/wiki/Testing-prerelease-OTA-updates)
+* [Releasing a Gateway OTA Update](https://github.com/WebThingsIO/wiki/wiki/How-To-Release-a-Gateway-OTA-Update)
+* [Using the staging server](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Use-the-staging-server-for-testing)
+#### Add-Ons
+* [Introduction to Add-ons](https://github.com/WebThingsIO/addon-list/blob/master/guidelines.md)
+* [Creating an Add-on](https://github.com/WebThingsIO/wiki/wiki/HOWTO%3A-Create-an-add-on)
+* [Configuring an Add-on](https://github.com/WebThingsIO/wiki/wiki/Add-on-Configuration)
+* [Publishing an Add-on](https://github.com/WebThingsIO/addon-list#readme)
+* Examples:
+  * [Adapter Add-on](https://github.com/WebThingsIO/example-adapter)
+  * [Notifier Add-on](https://github.com/WebThingsIO/example-notifier)
+  * [Extension Add-on](https://github.com/WebThingsIO/example-extension)
+* Add-on APIs
+  * [Node.js Add-on API](https://github.com/WebThingsIO/gateway-addon-node)
+  * [Python Add-on API](https://github.com/WebThingsIO/gateway-addon-python)
+* [Adapter Inter-process communication](https://github.com/WebThingsIO/wiki/wiki/Adapter-IPC)
+* [Debug Controller](https://github.com/WebThingsIO/wiki/wiki/Using-the-debug-controller)
 
-### Third Party Libraries
-* 🌐 [IoT.js](https://github.com/rzr/webthing-iotjs)
-* 🌐 [Moddable SDK](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/network/webthings.md)
+### WebThings Framework
+[WebThings Framework](https://webthings.io/framework/) is a collection of re-usable software components to help developers build their own web things which directly expose the Web Thing API.
+#### WebThings Libraries
+* [Node.js](https://github.com/WebThingsIO/webthing-node)
+* [Python](https://github.com/WebThingsIO/webthing-python)
+* [Java](https://github.com/WebThingsIO/webthing-java)
+* [Rust](https://github.com/WebThingsIO/webthing-rust)
+* [Arduino](https://github.com/WebThingsIO/webthing-arduino)
+* [MicroPython](https://github.com/WebThingsIO/webthing-upy)
+#### Third Party Libraries
+* [Moddable](https://github.com/Moddable-OpenSource/moddable/blob/public/documentation/network/webthings.md)
+* [Atmosphere IoT](https://developer.atmosphereiot.com/documents/guides/gettingstartedwebthings.html)
+* [IoT.js](https://github.com/rzr/webthing-iotjs) by rzr
+* [C#](https://github.com/lillo42/webthing-csharp) by lillo42
+* [Go](https://github.com/rzr/webthing-go) by rzr
+* [Go](https://github.com/dravenk/webthing-go) by dravenk
+* [ESP-IDF](https://github.com/akshayvernekar/esp-webthing) by akshayvernekar
+* [PHP](https://github.com/maliknaik16/webthing-php) by maliknaik16
+* [Python](https://github.com/hidaris/aiowebthing) by hidaris
 
-## Web Thing API
-* 🌐 [Web Thing API specification](https://iot.mozilla.org/wot/)
-* 🌐 [WoT Capability Schemas](https://iot.mozilla.org/schemas/)
+### WebThings Cloud
+WebThings Cloud is a collection of cloud services for remotely managing web things over the internet. WebThings Cloud includes a remote access service which can create an end-to-end encrypted tunnel between a WoT gateway (or device) and a WoT client so that it can be securely accessed over the internet.
+* [How Remote Access Works](https://github.com/WebThingsIO/registration_server/blob/master/doc/flow.md)
+* [Registration Server API](https://github.com/WebThingsIO/registration_server/blob/master/doc/api.md)
+
+### Tips
+* [Glossary of Terms](https://github.com/WebThingsIO/wiki/wiki/Glossary-of-Terms)
+* [Installing Node.js](https://github.com/WebThingsIO/wiki/wiki/Installing-Node.js)
+* [Accessing the command line on the Raspberry Pi](https://github.com/WebThingsIO/wiki/wiki/Logging-into-the-Raspberry-Pi)
+* [Configuring GPIO on the Raspberry Pi](https://github.com/webthingsio/wiki/wiki/Configuring-GPIO-for-use-with-the-gpio-adapter)
+* [Running OAuth locally](https://github.com/WebThingsIO/wiki/wiki/Running-OAuth-Locally)
+* [Command line tool for exploring new Zigbee and Z-Wave devices](https://github.com/WebThingsIO/wiki/wiki/Command-Line-Tool)
+* [Installing OpenZWave](https://github.com/WebThingsIO/wiki/wiki/Installing-OpenZWave)
+* [Node for OpenZWave](https://github.com/WebThingsIO/wiki/wiki/Node-for-OpenZWave)
+* [Debugging Z-Wave](https://github.com/WebThingsIO/wiki/wiki/Debugging-OpenZWave)
+* [Debugging Zigbee](https://github.com/WebThingsIO/wiki/wiki/Debugging-Zigbee)
+* [Recording Zigbee frames sent by XCTU](https://github.com/WebThingsIO/wiki/wiki/Recording-Frames-sent-by-XCTU-(Zigbee))
+* [Zigbee attributes](https://github.com/WebThingsIO/wiki/wiki/Zigbee-Attributes)
+* [Setup of eslint in PyCharm](https://github.com/WebThingsIO/wiki/wiki/PyCharm-Setup)
+* [Loop mounting a Raspberry Pi image file under Linux](https://github.com/WebThingsIO/wiki/wiki/Loop-mounting-a-Raspberry-Pi-image-file-under-Linux)
+
+### External Resources
+* [Mozilla Hacks Blog - Web of Things](https://hacks.mozilla.org/category/web-of-things/) - Original Mozilla WebThings blog
+* [TwoBraids Blog](https://www.twobraids.com/search/label/programming) - Blog posts about WebThings

--- a/_config.yml
+++ b/_config.yml
@@ -1,6 +1,6 @@
 theme: jekyll-theme-slate
-title: Mozilla WebThings Documentation
-description: A guide to using the WebThings Gateway and WebThings Framework
+title: WebThings Documentation
+description: A guide to using and developing for the WebThings IoT Platform
 baseurl: /docs
 show_downloads: false
 encoding: UTF-8

--- a/gateway-getting-started-guide.md
+++ b/gateway-getting-started-guide.md
@@ -2,7 +2,7 @@
 
 ## WebThings Gateway for Raspberry Pi®
 
-[WebThings Gateway](https://iot.mozilla.org/gateway/) is a software distribution for smart home gateways which allows users to directly monitor and control their smart home over the web, without a middleman.
+[WebThings Gateway](https://webthings.io/gateway/) is a software distribution for smart home gateways which allows users to directly monitor and control their smart home over the web, without a middleman.
 
 ### What you will need
 
@@ -16,7 +16,7 @@
 
 ### 1. Download Image
 
-First download the latest gateway image from the [Mozilla IoT website](https://iot.mozilla.org/gateway/).
+First download the latest gateway image from the [WebThings website](https://webthings.io/gateway/).
 
 ### 2. Flash Image
 
@@ -66,11 +66,11 @@ Select the desired network and enter the password when prompted.  The "Connectin
 
 After you've connected the Raspberry Pi to your wireless network, you should ensure that your laptop/tablet/smartphone is connected to the same Wi-Fi network and then navigate to **http://gateway.local** in your web browser.
 
-You will then be given the option to register a free subdomain to safely access your gateway over the Internet using a [secure tunnelling service](https://github.com/WebThingsIO/registration_server/blob/master/doc/flow.md) provided by Mozilla.
+You will then be given the option to register a free subdomain to safely access your gateway over the Internet using a [secure tunnelling service](https://github.com/WebThingsIO/registration_server/blob/master/doc/flow.md).
 
 <img alt="choose subdomain" src="./images/choose_subdomain.png">
 
-Enter your choice of subdomain and an email address in case you need to retrieve your subdomain later to re-install on a new gateway. Click "Create" and wait a few moments for the subdomain registration to complete.  Try loading your subdomain on your smartphone or computer by loading https://SUBDOMAIN.mozilla-iot.org (where 'SUBDOMAIN' is the subdomain name you've chosen).
+Enter your choice of subdomain and an email address in case you need to retrieve your subdomain later to re-install on a new gateway. Click "Create" and wait a few moments for the subdomain registration to complete.  Try loading your subdomain on your smartphone or computer by loading https://SUBDOMAIN.webthings.io (where 'SUBDOMAIN' is the subdomain name you've chosen).
 
 
 **Notes:**

--- a/gateway-user-guide.md
+++ b/gateway-user-guide.md
@@ -1,14 +1,14 @@
 # User Guide
 
 ## WebThings Gateway for Raspberry Pi User Guide
-[WebThings Gateway](https://iot.mozilla.org/gateway) by Mozilla is a software distribution for smart home gateways which allows users to directly monitor and control their smart home over the web, without a middleman.
+[WebThings Gateway](https://webthings.io/gateway) is a software distribution for smart home gateways which allows users to directly monitor and control their smart home over the web, without a middleman.
 
-This guide assumes you have already followed the [Getting Started Guide](https://iot.mozilla.org/docs/gateway-getting-started-guide.html) to bring your gateway online.
+This guide assumes you have already followed the [Getting Started Guide](https://webthings.io/docs/gateway-getting-started-guide.html) to bring your gateway online.
 
 ## I. Introduction
 
 Congratulations on choosing to set up your own private Smart Home Gateway. This guide provides an overview of
-the Mozilla WebThings Gateway. This guide covers release version 0.12. Hereafter we will
+the WebThings Gateway. This guide covers release version 0.12. Hereafter we will
 usually just refer to it as the "gateway".
 
 The gateway lets you directly monitor and control your home over the web. Unlike many smart home hubs and connected
@@ -28,7 +28,7 @@ and a Zigbee USB dongle. The bottom row shows a door sensor, smart plugs, smart 
 
 Currently there is no specific smartphone application for the gateway, but you can load your unique gateway url into a smartphone browser application and save it to your home screen, which makes it work just like any other application.
 
-If you use Mozilla's tunneling service, your gateway url will be of the form `[your_subdomain].mozilla-iot.org`.
+If you use the WebThings Cloud tunneling service, your gateway url will be of the form `[your_subdomain].webthings.io`.
 
 We recommend that you **bookmark** the web address on all devices that you have access to from home.
 It is also handy to save your WebThings Gateway as a **web application on the home screen** of your phones and tablets.
@@ -70,7 +70,7 @@ Configure the weather add-on:
 
 <img src="./images/weather_addon_configuration.png" alt="weather addon settings" width="800">
 
-Return to the main Things page (https://SUBDOMAIN.mozilla-iot.org/things) and click the "+" icon to add a new thing.  Scanning for new devices should discover the Weather thing with the location name you specified.  Click "Save".
+Return to the main Things page (https://SUBDOMAIN.webthings.io/things) and click the "+" icon to add a new thing.  Scanning for new devices should discover the Weather thing with the location name you specified.  Click "Save".
 
 <img src="./images/weather_thing_add.png" alt="add weather thing" width="800">
 
@@ -137,7 +137,7 @@ the <img src="./images/image34.png" alt="edit" width="20"> icon in the bottom ri
 
 ## IV. Rules: Automate Your Home
 
-Now that your Mozilla WebThings Gateway is set up and your smart things are connected, you can start automating
+Now that your WebThings Gateway is set up and your smart things are connected, you can start automating
 your home for your convenience by creating 'Rules'. Practice creating a rule by following the next few steps.
 
 ### Create a Rule
@@ -324,7 +324,7 @@ development tools.
 
 ## IX. Support
 
-For support, please sign up to our IoT [Discourse forum](https://discourse.mozilla.org/c/iot), join us on [Matrix](https://chat.mozilla.org) in the #iot channel, or post issues on [GitHub](https://github.com/WebThingsIO/gateway/issues).
+For support, please sign up to our [forum](https://discourse.mozilla.org/c/iot), join us on [Matrix](https://chat.mozilla.org) in the #iot channel, or post issues on [GitHub](https://github.com/WebThingsIO/gateway/issues).
 
 ## Appendix: Tips on Pairing and Unpairing Smart Devices
 


### PR DESCRIPTION
I've re-branded the documentation and tried to centralise all the documentation I know about on the front page (including the current docs, wiki and various READMEs on GitHub). I've also split the front page into User Guide and Developer Guide to target those two different audiences.

I haven't yet generated new screenshots for the Getting Started Guide and User Guide.

I suggest that in the future we try to centralise most of this documentation on the /docs sub-site, rather than linking out to various wiki pages and READMEs, but will hold off on doing that until we have a new documentation system in place.

This is intended as an interim step for the new webthings.io website until that is finished.